### PR TITLE
bugfix: fix a react project compile issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"@tarojs/components": "^3.2.10",
+		"@tarojs/plugin-framework-react": "^3.6.8",
 		"@tarojs/react": "^3.2.10",
 		"@tarojs/runtime": "^3.2.10",
 		"@tarojs/taro": "^3.2.10",
@@ -37,6 +38,8 @@
 		"eslint-plugin-import": "^2.12.0",
 		"eslint-plugin-react": "^7.8.2",
 		"eslint-plugin-react-hooks": "^1.6.1",
+		"postcss": "^8.4.25",
+		"postcss-loader": "^7.3.3",
 		"stylelint": "9.3.0",
 		"typescript": "^3.8.2"
 	}


### PR DESCRIPTION
修复 #30 所提及的 react 小程序编译不过的问题。

```text
👽 Taro v3.6.8

Tips:
1. 预览模式生成的文件较大，设置 NODE_ENV 为 production 可以开启压缩。
Example:
$ NODE_ENV=production taro build --type weapp --watch



编译  发现入口  src/app.tsx
编译  发现页面  src/pages/index/index.tsx
编译  发现页面  src/pages/nodes/nodes.tsx
编译  发现页面  src/pages/hot/hot.tsx
编译  发现页面  src/pages/node_detail/node_detail.tsx
编译  发现页面  src/pages/thread_detail/thread_detail.tsx
✅  编译成功 7/13/2023, 8:59:12 AM
```